### PR TITLE
Jar build changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ You can use Burp's built-in browser to deploy PwnFox for Chromium. Here are the 
 /Applications/Burp Suite Community Professional.app/Contents/Resources/app/burpbrowser/{VERSION}/Chromium.app/Contents/MacOS/Chromium
 ```
 
-## Compiling the extension on your own with Maven
+## Building from Sources
+> This project depends on the IntelliJ GUI Designer. Make sure you have the latest [Swing UI Designer](https://plugins.jetbrains.com/plugin/25304-swing-ui-designer) plugin installed if you would like to edit the GUI layout. 
+
 ```
 git clone https://github.com/adeadfed/PwnFox-For-Chromium
 cd PwnFox-For-Chromium/
@@ -67,12 +69,3 @@ You can edit Chromium proxy configuration and enable/disable it using the built-
 - All extension settings can be managed in BurpSuite directly
 - Additional options for proxy configuration in the bundled Chromium extensions
 - You can keep unique Chromium data for each engagement by separating the Chromium profile data directories
-
-## Building
-This project depends on the IntelliJ GUI Designer. Make sure you have the latest [Swing UI Designer](https://plugins.jetbrains.com/plugin/25304-swing-ui-designer) plugin installed. 
-
-To build it yourself using Maven: 
-
-1. Ensure IntelliJ is set to "Generate GUI into: Java source code on compilation" (Settings > Editor > GUI Designer).
-2. Run `mvn clean install`.
-3. Load `target/PwnFox-For-Chromium-1.3.2-jar-with-dependencies.jar` into Burp.

--- a/README.md
+++ b/README.md
@@ -67,3 +67,12 @@ You can edit Chromium proxy configuration and enable/disable it using the built-
 - All extension settings can be managed in BurpSuite directly
 - Additional options for proxy configuration in the bundled Chromium extensions
 - You can keep unique Chromium data for each engagement by separating the Chromium profile data directories
+
+## Building
+This project depends on the IntelliJ GUI Designer. Make sure you have the latest [Swing UI Designer](https://plugins.jetbrains.com/plugin/25304-swing-ui-designer) plugin installed. 
+
+To build it yourself using Maven: 
+
+1. Ensure IntelliJ is set to "Generate GUI into: Java source code on compilation" (Settings > Editor > GUI Designer).
+2. Run `mvn clean install`.
+3. Load `target/PwnFox-For-Chromium-1.3.2-jar-with-dependencies.jar` into Burp.

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,6 @@
         </dependency>
         <dependency>
             <groupId>com.intellij</groupId>
-            <artifactId>javac2</artifactId>
-            <version>7.0.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.intellij</groupId>
             <artifactId>forms_rt</artifactId>
             <version>7.0.3</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,7 @@
     <version>1.3.2</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -44,29 +43,20 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>ideauidesigner-maven-plugin</artifactId>
-                <version>1.0-beta-1</version>
+                <version>3.6.0</version> <configuration>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+                <appendAssemblyId>true</appendAssemblyId>
+            </configuration>
                 <executions>
                     <execution>
-                        <goals>
-                            <goal>javac2</goal>
-                        </goals>
+                        <id>make-assembly</id>
+                        <phase>package</phase> <goals>
+                        <goal>single</goal>
+                    </goals>
                     </execution>
                 </executions>
-
-                <configuration>
-                    <fork>true</fork>
-                    <debug>true</debug>
-                    <failOnError>true</failOnError>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -43,18 +43,20 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.8.0</version> <configuration>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-                <appendAssemblyId>true</appendAssemblyId>
-            </configuration>
+                <version>3.8.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <appendAssemblyId>true</appendAssemblyId>
+                </configuration>
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>package</phase> <goals>
-                        <goal>single</goal>
-                    </goals>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version> <configuration>
+                <version>3.8.0</version> <configuration>
                 <descriptorRefs>
                     <descriptorRef>jar-with-dependencies</descriptorRef>
                 </descriptorRefs>


### PR DESCRIPTION
Not breaking changes to Pom.xml:
1. allow the Jar to be build using `mvn clean package` / `mvn clean install` with all dependencies.
2. Still support `mvn clean compile assembly:single` for clean build with no extra files.
3. Remove unused mvn plugins and dependencies. Jar should now be 3 times lighter.